### PR TITLE
fix: Use version which conforming to PEP-0440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-salesforce',
-      version='meltano.1.5.0',
+      version='1.5.1',
       description='Singer.io tap for extracting data from the Salesforce API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
since setuptools>=66, it is no loger supported for legacy versioning