### PR TITLE
fix: Make start date optional with relaxed validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-salesforce',
       py_modules=['tap_salesforce'],
       install_requires=[
           'requests==2.31.0',
-          'singer-python==5.3.1',
+          'singer-python~=5.13',
           'xmltodict==0.11.0',
           'simple-salesforce<1.0', # v1.0 requires `requests==2.22.0`
           # fix version conflicts, see https://gitlab.com/meltano/meltano/issues/193

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-salesforce',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_salesforce'],
       install_requires=[
-          'requests==2.32.0',
+          'requests==2.32.2',
           'singer-python~=5.13',
           'xmltodict==0.11.0',
           'simple-salesforce<1.0', # v1.0 requires `requests==2.22.0`

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -228,10 +228,13 @@ class Salesforce():
 
         # validate start_date
         self.default_start_date = (
-            singer_utils.strptime(default_start_date)
+            singer_utils.strptime_to_utc(default_start_date)
             if default_start_date
             else (singer_utils.now() - timedelta(weeks=4))
         ).isoformat()
+
+        if default_start_date:
+            LOGGER.info("Parsed start date '%s' from value '%s'", self.default_start_date, default_start_date)
 
     # pylint: disable=anomalous-backslash-in-string,line-too-long
     def check_rest_quota_usage(self, headers):

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -2,6 +2,7 @@ import re
 import time
 import backoff
 import requests
+from datetime import timedelta
 from requests.exceptions import RequestException
 import singer
 import singer.utils as singer_utils
@@ -218,7 +219,6 @@ class Salesforce():
         self.quota_percent_total = float(quota_percent_total) if quota_percent_total is not None else 80
         self.is_sandbox = is_sandbox is True or (isinstance(is_sandbox, str) and is_sandbox.lower() == 'true')
         self.select_fields_by_default = select_fields_by_default is True or (isinstance(select_fields_by_default, str) and select_fields_by_default.lower() == 'true')
-        self.default_start_date = default_start_date
         self.rest_requests_attempted = 0
         self.jobs_completed = 0
         self.data_url = "{}/services/data/v53.0/{}"
@@ -227,7 +227,11 @@ class Salesforce():
         self.auth = SalesforceAuth.from_credentials(credentials, is_sandbox=self.is_sandbox)
 
         # validate start_date
-        singer_utils.strptime(default_start_date)
+        self.default_start_date = (
+            singer_utils.strptime(default_start_date)
+            if default_start_date
+            else (singer_utils.now() - timedelta(weeks=4))
+        ).isoformat()
 
     # pylint: disable=anomalous-backslash-in-string,line-too-long
     def check_rest_quota_usage(self, headers):


### PR DESCRIPTION
### Changes
- Fallback to a dynamic default start date of 4 weeks, if not otherwise provided from state or config
- Relax start date validation using `singer_utils.strptime_to_utc` over deprecated `singer_utils.strptime`
