### PR TITLE
fix: Exclude location fields when `api_type` is `BULK`

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -186,7 +186,7 @@ def do_discover(sf: Salesforce, streams: list[str]):
                 f, mdata)
 
             # Compound Address fields cannot be queried by the Bulk API
-            if f['type'] == "address" and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
+            if (f['type'] == "address"  or f["compoundFieldName"] is not None) and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
                 unsupported_fields.add(
                     (field_name, 'cannot query compound address fields with bulk API'))
 

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -186,7 +186,7 @@ def do_discover(sf: Salesforce, streams: list[str]):
                 f, mdata)
 
             # Compound Address fields cannot be queried by the Bulk API
-            if (f['type'] == "address"  or f["compoundFieldName"] is not None) and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
+            if f['type'] in ("address", "location") and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
                 unsupported_fields.add(
                     (field_name, 'cannot query compound address fields with bulk API'))
 

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -196,7 +196,7 @@ def field_to_property_schema(field, mdata):
     elif sf_type == "time":
         property_schema['type'] = "string"
     elif sf_type in LOOSE_TYPES:
-        return property_schema, mdata  # No type = all types
+        property_schema['type'] = "string"
     elif sf_type in BINARY_TYPES:
         mdata = metadata.write(mdata, ('properties', field_name), "inclusion", "unsupported")
         mdata = metadata.write(mdata, ('properties', field_name),

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -196,7 +196,7 @@ def field_to_property_schema(field, mdata):
     elif sf_type == "time":
         property_schema['type'] = "string"
     elif sf_type in LOOSE_TYPES:
-        property_schema['type'] = "string"
+        return property_schema, mdata  # No type = all types
     elif sf_type in BINARY_TYPES:
         mdata = metadata.write(mdata, ('properties', field_name), "inclusion", "unsupported")
         mdata = metadata.write(mdata, ('properties', field_name),


### PR DESCRIPTION
In the current implementation of the tap, fields described with `type=address` are correctly excluded when using `api_type=BULK`.

Although,  this is not the case for geolocation fields (described with `type=location`).

I'm not a Salesforce specialist per se, but know that the changes I'm applying on this branch solved the issue described [here](https://github.com/MeltanoLabs/tap-salesforce/issues/42).

In my specific case I had a field like this:

```
                    "Geolocation__c": {
                        "type": [
                            "number",
                            "object",
                            "null"
                        ],
                        "properties": {
                            "longitude": {
                                "type": [
                                    "null",
                                    "number"
                                ]
                            },
                            "latitude": {
                                "type": [
                                    "null",
                                    "number"
                                ]
                            }
                        }
                    },
```

As it's a compound field, split over multiple properties (`longitude` and `latitude`), the parent field `Geolocation__c` does not have much value as the relevant information is propagated in the "sub-fields" (`latitude` and `longitude`).

So what I'm doing in this PR is to ensure that:
- `Geolocation__c` is marked with `unsupported` in the schema metadata (snippet below) while still ensuring that the "sub-fields" are correctly queried.

Snippet of the excluded schema after this PR:
```
                {
                    "breadcrumb": [
                        "properties",
                        "Geolocation__c"
                    ],
                    "metadata": {
                        "inclusion": "unsupported",
                        "unsupported-description": "cannot query compound address fields with bulk API"
                    }
                },
```

Snippet of the "sub-fields" in the schema:

```
                    "Geolocation__Latitude__s": {
                        "type": [
                            "null",
                            "number"
                        ]
                    },
                    "Geolocation__Longitude__s": {
                        "type": [
                            "null",
                            "number"
                        ]
                    },
```