### PR TITLE
Add configuration options for PK chunking to help w/the initial sync of large/wide tables

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -520,7 +520,8 @@ def main_impl():
             is_sandbox=CONFIG.get('is_sandbox'),
             select_fields_by_default=CONFIG.get('select_fields_by_default'),
             default_start_date=CONFIG.get('start_date'),
-            api_type=CONFIG.get('api_type'))
+            api_type=CONFIG.get('api_type'),
+            pk_chunking=CONFIG.get('pk_chunking', False))
         sf.login()
 
         if args.discover:

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -521,7 +521,7 @@ def main_impl():
             select_fields_by_default=CONFIG.get('select_fields_by_default'),
             default_start_date=CONFIG.get('start_date'),
             api_type=CONFIG.get('api_type'),
-            pk_chunking=CONFIG.get('pk_chunking', []))
+            pk_chunking=CONFIG.get('pk_chunking', {}))
         sf.login()
 
         if args.discover:

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -521,7 +521,7 @@ def main_impl():
             select_fields_by_default=CONFIG.get('select_fields_by_default'),
             default_start_date=CONFIG.get('start_date'),
             api_type=CONFIG.get('api_type'),
-            pk_chunking=CONFIG.get('pk_chunking', False))
+            pk_chunking=CONFIG.get('pk_chunking', []))
         sf.login()
 
         if args.discover:

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -206,7 +206,8 @@ class Salesforce():
                  is_sandbox=None,
                  select_fields_by_default=None,
                  default_start_date=None,
-                 api_type=None):
+                 api_type=None,
+                 pk_chunking=False):
         self.api_type = api_type.upper() if api_type else None
         self.session = requests.Session()
         if isinstance(quota_percent_per_run, str) and quota_percent_per_run.strip() == '':
@@ -222,7 +223,7 @@ class Salesforce():
         self.rest_requests_attempted = 0
         self.jobs_completed = 0
         self.data_url = "{}/services/data/v53.0/{}"
-        self.pk_chunking = False
+        self.pk_chunking = pk_chunking
 
         self.auth = SalesforceAuth.from_credentials(credentials, is_sandbox=self.is_sandbox)
 

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -207,7 +207,7 @@ class Salesforce():
                  select_fields_by_default=None,
                  default_start_date=None,
                  api_type=None,
-                 pk_chunking=False):
+                 pk_chunking=[]):
         self.api_type = api_type.upper() if api_type else None
         self.session = requests.Session()
         if isinstance(quota_percent_per_run, str) and quota_percent_per_run.strip() == '':

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -207,7 +207,7 @@ class Salesforce():
                  select_fields_by_default=None,
                  default_start_date=None,
                  api_type=None,
-                 pk_chunking=[]):
+                 pk_chunking={}):
         self.api_type = api_type.upper() if api_type else None
         self.session = requests.Session()
         if isinstance(quota_percent_per_run, str) and quota_percent_per_run.strip() == '':

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -144,6 +144,8 @@ class Bulk():
         batch_status['job_id'] = job_id
 
         if batch_status['failed']:
+            for batch in [b for b in batch_status['all'] if b['state'] == "Failed"]:
+                LOGGER.info(batch['stateMessage'])
             raise TapSalesforceException("One or more batches failed during PK chunked job")
 
         # Close the job after all the batches are complete
@@ -218,7 +220,7 @@ class Bulk():
             if not queued_batches and not in_progress_batches:
                 completed_batches = [b['id'] for b in batches if b['state'] == "Completed"]
                 failed_batches = [b['id'] for b in batches if b['state'] == "Failed"]
-                return {'completed': completed_batches, 'failed': failed_batches}
+                return {'completed': completed_batches, 'failed': failed_batches, 'all': batches}
             else:
                 time.sleep(PK_CHUNKED_BATCH_STATUS_POLLING_SLEEP)
                 batches = self._get_batches(job_id)

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -48,9 +48,10 @@ class Bulk():
 
     def query(self, catalog_entry, state):
         self.check_bulk_quota_usage()
+        pk_chunking = self.sf.pk_chunking.get('enabled')
         chunked_tables = self.sf.pk_chunking.get('tables', [])
 
-        if catalog_entry['stream'] in chunked_tables:
+        if pk_chunking and catalog_entry['stream'] in chunked_tables:
             for record in self._bulk_query_with_pk_chunking(catalog_entry, state):
                 yield record
         else:

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -49,7 +49,7 @@ class Bulk():
     def query(self, catalog_entry, state):
         self.check_bulk_quota_usage()
 
-        if self.sf.pk_chunking:
+        if catalog_entry['stream'] in self.sf.pk_chunking:
             for record in self._bulk_query_with_pk_chunking(catalog_entry, state):
                 yield record
         else:

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -132,7 +132,7 @@ def sync_records(sf, catalog_entry, state, counter, state_msg_threshold):
 
         replication_key_value = replication_key and singer_utils.strptime_with_tz(rec[replication_key])
 
-        if sf.pk_chunking:
+        if sf.pk_chunking.get('enabled'):
             if replication_key_value and replication_key_value <= start_time and replication_key_value > chunked_bookmark:
                 # Replace the highest seen bookmark and save the state in case we need to resume later
                 chunked_bookmark = singer_utils.strptime_with_tz(rec[replication_key])
@@ -164,7 +164,7 @@ def sync_records(sf, catalog_entry, state, counter, state_msg_threshold):
             state, catalog_entry['tap_stream_id'], 'version', None)
 
     # If pk_chunking is set, only write a bookmark at the end
-    if sf.pk_chunking:
+    if sf.pk_chunking.get('enabled'):
         # Write a bookmark with the highest value we've seen
         state = singer.write_bookmark(
             state,


### PR DESCRIPTION
I ran into two problems when syncing tables with the BULK api. 

- If the job results are over 1GB or query takes more than 5 mins ([described here](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_bulk_query_processing.htm) in SF docs), the job fails w/a "retried 30 times" error
- Objects in the `Note` table in one of our SF accounts must associated w/a large number of other objects, b/c we get this error: `InvalidBatch : Failed to process query: OPERATION_TOO_LARGE: exceeded 20000 distinct ids`

#### Addressing the first problem
We found it helpful to enable PK chunking for specific tables from the get go, rather than wait for it to fail over to PK chunking after a query timeout. The tables in question are fairly large and have lots of columns.

The existing code is supposed to fail over to PK chunking when a query timeout occurs, but it didn't in our case. I believe the behavior of the API may have changed, based on what the [the original tap-salesforce](https://github.com/singer-io/tap-salesforce/blob/master/tap_salesforce/salesforce/bulk.py#L104-L107) is now doing now (and that seems outdated too, 15 vs 30 retries).

I'd like to submit a separate PR to address the fail over problem.

#### Addressing the second one
We got the "OPERATION_TOO_LARGE" error with and without PK chunking. One of the solutions is to do a smaller query, so a smaller batch size with PK chunking fixed it.

#### Configuration options for PK chunking

I'll happily submit PR's to update the docs. I added 3 config options:
```
config:
  pk_chunking:
    enabled: true
    tables
    - TableA
    - TableB
    polling_sleep_time: 20
```
