### PR TITLE
fix: Handle 406 http errors

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -11,7 +11,8 @@ from tap_salesforce.salesforce.bulk import Bulk
 from tap_salesforce.salesforce.rest import Rest
 from tap_salesforce.salesforce.exceptions import (
     TapSalesforceException,
-    TapSalesforceQuotaExceededException)
+    TapSalesforceQuotaExceededException,
+    SFDCCustomNotAcceptableError)
 from tap_salesforce.salesforce.credentials import SalesforceAuth
 
 
@@ -137,6 +138,25 @@ QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS = set(['DataType',
 
 def log_backoff_attempt(details):
     LOGGER.info("ConnectionError detected, triggering backoff: %d try", details.get("tries"))
+
+
+def raise_for_status(resp):
+    """
+    Adds additional handling of HTTP Errors.
+
+    `CustomNotAcceptable` is returned during discovery with status code 406.
+        This error does not seem to be documented on Salesforce, and possibly
+        is not the best error that Salesforce could return. It also appears
+        that this error is ephemeral and resolved after retries.
+    """
+    if resp.status_code == 406 and 'CustomNotAcceptable' in resp.reason:
+        err_msg = (
+            f"{resp.status_code} Client Error: {resp.reason} "
+            f"for url: {resp.url}"
+        )
+        raise SFDCCustomNotAcceptableError(err_msg)
+    else:
+        resp.raise_for_status()
 
 
 def field_to_property_schema(field, mdata):
@@ -269,7 +289,7 @@ class Salesforce():
 
     # pylint: disable=too-many-arguments
     @backoff.on_exception(backoff.expo,
-                          requests.exceptions.ConnectionError,
+                          (requests.exceptions.ConnectionError, SFDCCustomNotAcceptableError),
                           max_tries=10,
                           factor=2,
                           on_backoff=log_backoff_attempt)
@@ -283,7 +303,7 @@ class Salesforce():
         else:
             raise TapSalesforceException("Unsupported HTTP method")
 
-        resp.raise_for_status()
+        raise_for_status(resp)
 
         if resp.headers.get('Sforce-Limit-Info') is not None:
             self.rest_requests_attempted += 1

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -149,11 +149,14 @@ def raise_for_status(resp):
         is not the best error that Salesforce could return. It also appears
         that this error is ephemeral and resolved after retries.
     """
-    if resp.status_code == 406 and 'CustomNotAcceptable' in resp.reason:
+    if resp.status_code != 200:
         err_msg = (
             f"{resp.status_code} Client Error: {resp.reason} "
             f"for url: {resp.url}"
         )
+        LOGGER.warning(err_msg)
+
+    if resp.status_code == 406 and 'CustomNotAcceptable' in resp.reason:
         raise SFDCCustomNotAcceptableError(err_msg)
     else:
         resp.raise_for_status()

--- a/tap_salesforce/salesforce/exceptions.py
+++ b/tap_salesforce/salesforce/exceptions.py
@@ -6,3 +6,17 @@ class TapSalesforceException(Exception):
 
 class TapSalesforceQuotaExceededException(TapSalesforceException):
     pass
+
+
+class SFDCCustomNotAcceptableError(Exception):
+    """
+    SFDC returned CustomNotAcceptable error with HTTP Error code 406.
+
+    This error is sometimes returned when many discovery calls are made
+    in quick succession. There does not seem to be documentation on this error
+    on any salesforce documentation page or forum.
+    Example Error Message:
+    ```
+    requests.exceptions.HTTPError: 406 Client Error: CustomNotAcceptable for 
+    url: https://XXX.salesforce.com/services/data/v53.0/sobjects/XXX/describe
+    """


### PR DESCRIPTION
We have been noticing 406 errors when running discovery, specifically on the `.../describe` endpoint.

```
requests.exceptions.HTTPError: 406 Client Error: CustomNotAcceptable for url: https://XXX.salesforce.com/services/data/v53.0/sobjects/XXX/describe
```

This MR adds error handling for this. The error code 406 is new to me, so I wanted to look up what that meant. Salesforce's error codes page does not even document it. https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/errorcodes.htm

From the various pieces of literature I've read, it seems that the way to correct this issue is to set one of the accept, accept-encoding & accept-language appropriately, however we have not been providing alternate values for these headers and the error is encountered intermittently. 

My best guess is that a separate issue occurs, but salesforce does not report the actual error, and instead we are returned a 406, which is not very meaningful. To recover from these failures, we simply rerun the taps. However, adding a retry specific to this error code seems like a better approach and it will benefit the wider meltano / singer community.

MDN defines 406 as

>The HyperText Transfer Protocol (HTTP) 406 Not Acceptable client error response code indicates that the server cannot produce a response matching the list of acceptable values defined in the request's proactive content negotiation headers, and that the server is unwilling to supply a default representation.
>
>In practice, this error is very rarely used. Instead of responding using this error code, which would be cryptic for the end user and difficult to fix, servers ignore the relevant header and serve an actual page to the user. It is assumed that even if the user won't be completely happy, they will prefer this to an error code.
>
>If a server returns such an error status, the body of the message should contain the list of the available representations of the resources, allowing the user to choose among them.

source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406

Found the following through more google searches:

https://zendenwebdesign.com/causes-and-fixes-for-406-error-not-acceptable/

and also, in the salesforce community forums, users reported seeing this type of error:
https://trailhead.salesforce.com/trailblazer-community/feed/0D54S00000A93GsSAJ


# Related Issues

- closes: https://github.com/MeltanoLabs/tap-salesforce/issues/58