### PR TITLE
Sync History tables

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -211,6 +211,9 @@ def do_discover(sf: Salesforce, streams: list[str]):
 
             properties[field_name] = property_schema
 
+            if ((field_name=='OldValue') or (field_name=='NewValue')) and ('History' in sobject_name):
+                properties[field_name] = {'type': ['null', 'string']}
+
         if replication_key:
             mdata = metadata.write(
                 mdata, ('properties', replication_key), 'inclusion', 'automatic')


### PR DESCRIPTION
Salesforce has history tables which allow us to see how the data has changed over time.

Every history table has two important fields OldValue and NewValue. When the discovery process is running it cannot find the data type for these fields. The solution is these fields to be seen as type string.
