### PR TITLE
fix: remove ContentDocumentLink from restricted sfdc objects

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -78,7 +78,6 @@ UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS = {
 # The following objects have certain WHERE clause restrictions so we exclude them.
 QUERY_RESTRICTED_SALESFORCE_OBJECTS = {
     "Announcement",
-    "ContentDocumentLink",
     "CollaborationGroupRecord",
     "Vote",
     "IdeaComment",


### PR DESCRIPTION
ContentDocumentLink cannot be queried without a where clause by default; however, this setting can be changed (see [Salesforce docs](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_contentdocumentlink.htm)).

I propose removing this object from the restricted Salesforce Objects list so that it can be synced with this tap.

Closes #70.