### PR TITLE
remove null byte from bulk2 api

### DIFF
--- a/tap_salesforce/salesforce/bulk2.py
+++ b/tap_salesforce/salesforce/bulk2.py
@@ -24,7 +24,7 @@ class Bulk2:
         self._wait_for_job(job_id)
 
         for batch in self._get_next_batch(job_id):
-            yield from csv.DictReader(batch.decode("utf-8").splitlines())
+            yield from csv.DictReader(batch.decode("utf-8").replace('\0', '').splitlines())
 
     def _get_bulk_headers(self):
         return {**self.sf.auth.rest_headers, "Content-Type": "application/json"}


### PR DESCRIPTION
just like in the bulk api null bytes seem to make python very unhappy. this removes null bytes from anything that is returned from salesforce before it is sent to the python csv dict reader