### PR TITLE
fix: add a hard 12 month limit to tasks extraction

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -518,6 +518,7 @@ def main_impl():
             select_fields_by_default=CONFIG.get("select_fields_by_default"),
             default_start_date=CONFIG.get("start_date"),
             api_type=CONFIG.get("api_type"),
+            limit_tasks_month=CONFIG.get("limit_tasks_month"),
         )
         sf.login()
 


### PR DESCRIPTION
https://app.asana.com/1/12635457239181/project/1210455291696841/task/1210961613502452?focus=true

Adds an optional time limit (months) for tasks extraction