### PR TITLE
fix: Fix response handling error in `bulk2.py`

### DIFF
--- a/tap_salesforce/salesforce/bulk2.py
+++ b/tap_salesforce/salesforce/bulk2.py
@@ -62,7 +62,7 @@ class Bulk2:
                 break
 
             if status == "Failed":
-                raise Exception(f"Job failed: {resp.json()}")
+                raise Exception(f"Job failed: {resp}")
 
             time.sleep(BATCH_STATUS_POLLING_SLEEP)
 


### PR DESCRIPTION
Solves issue https://github.com/MeltanoLabs/tap-salesforce/issues/91

Adjust code in  line `bulk2.py:65` not to convert response to a `dict` using `resp.json()` when at that point in the code the `resp` object has already been converted to `dict` using `.json` in line `bulk2.py:58`, causing the code to fail with `AttributeError: 'dict' object has no attribute 'json'`.